### PR TITLE
fix a link to 0xf8.org

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -18,7 +18,7 @@ This guide describes the main steps to get and start working with Rspamd. In par
 
 * [Own mail server based on Dovecot, Postfix, MySQL, Rspamd and Debian 9 Stretch](https://thomas-leister.de/en/mailserver-debian-stretch/){:target="&#95;blank"} - a good example of all-in-one tutorial about how to setup your own mail server
 * [A guide to self-hosting your email on FreeBSD using Postfix, Dovecot, Rspamd, and LDAP.](https://www.c0ffee.net/blog/mail-server-guide){:target="&#95;blank"} - similar to the previous guide but uses a different technologies stack
-* [An alternative introduction to rspamd configuration](http://www.0xf8.org/2018/05/an-alternative-introduction-to-rspamd-configuration-introduction/){:target="&#95;blank"}
+* [An alternative introduction to rspamd configuration](https://www.0xf8.org/2018/05/an-alternative-introduction-to-rspamd-configuration-introduction/){:target="&#95;blank"}
 
 ## Preparation steps
 


### PR DESCRIPTION
There is a broken redirect from http to https, and a web-page cannot be opened without editing its URL.

```
$ curl -IL http://www.0xf8.org/2018/05/an-alternative-introduction-to-rspamd-configuration-introduction/
HTTP/1.1 302 Found
Date: Tue, 09 Apr 2019 10:10:41 GMT
Server: Apache
Location: https://www.0xf8.org2018/05/an-alternative-introduction-to-rspamd-configuration-introduction/
Content-Type: text/html; charset=iso-8859-1

curl: (6) Could not resolve host: www.0xf8.org2018
```