### PR TITLE
documentation support ES>=6.7 for elasctic module

### DIFF
--- a/doc/modules/elastic.md
+++ b/doc/modules/elastic.md
@@ -38,4 +38,9 @@ index_pattern = "rspamd-%Y.%m.%d";
 import_kibana = false;
 # Use https if needed
 use_https = false;
+# credential to connect to ElasticSearch (optional)
+user = "rspamd"
+password = "supersecret"
+# ingest_-geoip is a module (true if ElasticSearch >= 6.7.0)
+ingest_module = false;
 ~~~


### PR DESCRIPTION
I added an example with the default value.
I take this opportunity to complete the documentation for credential to connect to ElasticSearch. This information was missing.