### PR TITLE
DKIM signing: add documentation for oversigning openpgp and autocrypt headers

### DIFF
--- a/doc/modules/dkim_signing.md
+++ b/doc/modules/dkim_signing.md
@@ -261,7 +261,7 @@ sign_headers = '(o)from:(o)sender:(o)reply-to:(o)subject:(o)date:(o)message-id:\
 (o)to:(o)cc:(o)mime-version:(o)content-type:(o)content-transfer-encoding:\
 resent-to:resent-cc:resent-from:resent-sender:resent-message-id:\
 (o)in-reply-to:(o)references:list-id:list-owner:list-unsubscribe:\
-list-subscribe:list-post';
+list-subscribe:list-post:(o)openpgp:(o)autocrypt';
 ```
 
 As you can see, oversigned headers are prefixed with `(o)` string.


### PR DESCRIPTION
This updates the [DKIM signing module](https://rspamd.com/doc/modules/dkim_signing.html#default-sign_headers-after-173) documentation in case [pull request #2851](https://github.com/rspamd/rspamd/pull/2851) will be merged.

If it will not, please close this pull request. Thank you.