### PR TITLE
Update dmarc.md

### DIFF
--- a/doc/modules/dmarc.md
+++ b/doc/modules/dmarc.md
@@ -62,6 +62,8 @@ dmarc {
 }
 ~~~
 
+Note that the actions defined are prefilters.  This is important as setting 'quarantine = "add_header"' will cause rspamd to accept any mail that has a DMARC=quarantine result, then add a header to it, *even if that mail scores a result that would have otherwise resulted in the mail being marked as spam and rejected*.  
+
 ## Reporting
 
 From Rspamd 1.6 experimental support for generation of DMARC reports is provided.


### PR DESCRIPTION
Update dmarc.md to clarify the prefilter nature of the "action" settings and to clearly show that the quarantine=add_header setting will cause ALL mail, even mail that would otherwise be rejected as spam, to be accepted.