### PR TITLE
Reference the correct file for the default statistics settings

### DIFF
--- a/doc/configuration/statistic.md
+++ b/doc/configuration/statistic.md
@@ -30,7 +30,7 @@ Statistical tokens are stored in statfiles which, in turn, are mapped to specifi
 
 ## Statistics Configuration
 
-Starting from Rspamd 2.0, we propose to use `redis` as backed and `osb` as tokenizer and that are the default settings. Here are the default settings placed in `$CONFDIR/settings.conf`
+Starting from Rspamd 2.0, we propose to use `redis` as backed and `osb` as tokenizer and that are the default settings. Here are the default settings placed in `$CONFDIR/statistic.conf`
 
 ~~~ucl
 classifier "bayes" {


### PR DESCRIPTION
The [page on the statistical model](https://rspamd.com/doc/configuration/statistic.html) states that the default settings are 'placed in `$CONFDIR/settings.conf`'. However, they are actually in `$CONFDIR/statistic.conf`. This pull request changes the reference accordingly.