### PR TITLE
workers: clarify the default port number and Unix sockets support

### DIFF
--- a/doc/configuration/upstream.md
+++ b/doc/configuration/upstream.md
@@ -9,7 +9,7 @@ This document describes **upstreams**: list of servers that are selected by Rspa
 
 ## Introduction
 
-List of upstreams is a common structure used in various Rspamd configuration options when you need to setup some remote servers. For example, upstreams are used to connect to a Redis server, to select a DNS server and to establish a connection by Rspamd proxy. Servers in upstream list can be defined by IP addresses (IPv6 addresses should be enclosed in brackets):
+List of upstreams is a common structure used in various Rspamd configuration options when you need to setup some remote servers. For example, upstreams are used to connect to a Redis server, to select a DNS server and to establish a connection by Rspamd proxy. Servers in upstream list can be defined by IP addresses (IPv6 addresses should be enclosed in brackets) or Unix domain sockets:
 
     127.0.0.1,[::1]
 
@@ -24,6 +24,10 @@ You can also specify custom ports if they differ from the default ones (e.g. `53
 It is also possible to define upstreams priorities (described later), but in this case you must also specify a port number:
 
     127.0.0.1:53:10,8.8.8.8:53:1
+
+Unix sockets (starting with `/` or `.`) can also be specified, but priorities are not supported:
+
+    /tmp/rspamd.sock,fallback.example.com
 
 Upstreams line can be separated by commas or by semicolons in any combination. You can prepend rotation algorithm to the upstreams line to override the default rotation method (specific for each upstream list definition):
 

--- a/doc/workers/controller.md
+++ b/doc/workers/controller.md
@@ -8,7 +8,7 @@ Controller worker is used to manage rspamd stats, to learn rspamd and to serve W
 
 Internally, the controller worker is just a web server that accepts requests and sends replies using JSON serialization.
 Each command is defined by URL. Some commands are read only and are considered as `unprivileged` whilst other commands, such as
-maps modification, config modifications and learning requires higher level of privileges: `enable` level. The differece between levels is specified
+maps modification, config modifications and learning requires higher level of privileges: `enable` level. The difference between levels is specified
 by password. If only one password is specified in the configuration, it is used for both type of commands.
 
 ## Controller configuration

--- a/doc/workers/index.md
+++ b/doc/workers/index.md
@@ -46,7 +46,7 @@ worker "normal" {
 
 Here are options available to all workers:
 
-- `bind_socket` - a string that defines bind address of a worker.
+- `bind_socket` - a string that defines bind address of a worker. If the port number is omitted, port 11333 is assumed.
 - `count` - number of worker instances to run (some workers ignore that option, e.g. `hs_helper`)
 - `enabled` (1.6.2+) - a Boolean (`true` or `false`), enable or disable a worker (`true` by default)
 

--- a/doc/workers/rspamd_proxy.md
+++ b/doc/workers/rspamd_proxy.md
@@ -15,6 +15,11 @@ This worker provides different functionality to build multiple layers systems an
 * Compare results of mirrored request
 * Perform messages scan by own (self-scan mode)
 
+The `hosts` option for the `upstream` and `mirror` can specify IP addresses or
+Unix domain sockets as described in the
+[upstreams documentation]({{ site.baseurl }}/doc/configuration/upstream.html).
+If the port number is omitted, port 11333 is assumed.
+
 ## Milter support
 
 From Rspamd 1.6, rspamd proxy worker supports `milter` protocol which is supported by some of the popular MTA, such as Postfix or Sendmail. The introducing of this feature also finally obsoletes the [Rmilter](https://rspamd.com/rmilter/) project in honor of the new integration method. Milter support is presented in `rspamd_proxy` **only**, however, there are two possibilities to use milter protocol:


### PR DESCRIPTION
The default conf/worker-proxy.inc config example omits the port number
for "localhost", it was not obvious was port number will be used.

Add an example for a Unix socket. This appears to work as expected, but
does not support priorities at the moment. See also the comment in
src/libutil/addr.c, function rspamd_parse_host_port_priority.