### PR TITLE
Module, systemd bind_socket, and quickstart documentation updates

### DIFF
--- a/doc/architecture/index.md
+++ b/doc/architecture/index.md
@@ -22,7 +22,7 @@ Rspamd supports two main types of modules: internal modules written in C and ext
 
 ~~~ucl
 options {
- filters = "regexp,surbl,spf,dkim,fuzzy_check,chartable,email";
+ filters = "chartable,dkim,surbl,regexp,fuzzy_check";
  ...
 }
 ~~~

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -56,7 +56,7 @@ Some of these options are not available on some older platforms (Debian wheezy, 
 
 All packages are signed and should also be downloaded using `https`. Debugging packages are also available (`rspamd-debuginfo` for RPM packages and `rspamd-dbg` for DEB ones).
 
-ASAN packages are built with minimum optimizations and include [Address Sanitizer](https://en.wikipedia.org/wiki/AddressSanitizer) to allow debugging issues. These packages are significanlty slower and are not recommended for normal production usage (however, they **could** be) but they might be essential to debug Rspamd issues.
+ASAN packages are built with minimum optimizations and include [Address Sanitizer](https://en.wikipedia.org/wiki/AddressSanitizer) to allow debugging issues. These packages are significantly slower and are not recommended for normal production usage (however, they **could** be) but they might be essential to debug Rspamd issues.
 
 ### Resolver setup
 
@@ -82,7 +82,7 @@ dns {
 }
 ~~~
 
-If you use large scale DNS system you might want to set up `hash` rotation algorithm. It will significantly increase cache hit rate and reduce number of recursed requests if you have more than one upstream resolver:
+If you use large scale DNS system you might want to set up `hash` rotation algorithm. It will significantly increase cache hit rate and reduce number of recursive queries if you have more than one upstream resolver:
 
 ~~~ucl
  # local.d/options.inc
@@ -196,7 +196,8 @@ export ASAN_OPTIONS="log_path=/tmp/rspamd-asan"
 Or add this to `systemctl edit rspamd` if using systemd:
 
 ```
-ASAN_OPTIONS="log_path=/tmp/rspamd-asan"
+[Service]
+Environment="ASAN_OPTIONS=log_path=/tmp/rspamd-asan"
 ```
 
 Then, if you find out that Rspamd has crashed, you might want to use both core file (backtrace from it) and `/tmp/rspamd-asan.<pid>` file (where `<pid>` is the PID of the crashed process) to report your issue.

--- a/doc/modules/index.md
+++ b/doc/modules/index.md
@@ -19,7 +19,7 @@ configuration. If no `filters` attribute is defined, then all modules are disabl
 The default configuration enables all modules explicitly:
 
 ~~~ucl
-filters = "chartable,dkim,spf,surbl,regexp,fuzzy_check";
+filters = "chartable,dkim,surbl,regexp,fuzzy_check";
 ~~~
 
 Here is the list of available C modules:
@@ -27,7 +27,7 @@ Here is the list of available C modules:
 - [chartable](chartable.html): checks character sets of text parts in messages.
 - [dkim](dkim.html): performs DKIM signatures checks.
 - [fuzzy_check](fuzzy_check.html): checks a message's fuzzy hashes against public blacklists.
-- [spf](spf.html): checks SPF records for messages processed.
+- [spf](spf.html): checks SPF records for messages processed. Since rspamd 2.3, this C module has been removed and replaced by an equivalent Lua module.
 - [surbl](surbl.html): this module extracts URLs from messages and check them against
 public DNS black-lists to filter messages containing malicious URLs. Since Rspamd 2.0, this module has been removed and replaced by [rbl module](rbl.html). The existing configuration is automatically converted by Rspamd.
 - [regexp](regexp.html): the core module that allows to define regexp rules,
@@ -83,6 +83,7 @@ The following Lua modules are enabled in the default configuration (but may requ
 - [reputation](reputation.html) - a plugin that manages reputation evaluation based on various rules.
 - [rspamd_update](rspamd_update.html) - load dynamic rules and other rspamd updates (requires configuration)
 - [spamassassin](spamassassin.html) - load spamassassin rules (requires configuration)
+- [spf.html](spf.html) - perform SPF checks
 - [trie](trie.html) - uses suffix trie for extra-fast patterns lookup in messages. (requires configuration)
 - [whitelist](whitelist.html) - provides a flexible way to whitelist (or blacklist) messages based on SPF/DKIM/DMARC combinations
 - [url_redirector](url_redirector.html) - dereferences redirects (requires Redis configuration)

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -47,7 +47,7 @@ We assume that you are installing Postfix with your OS's package manager (e.g. `
     </a>
 <div id="main_cf" class="collapse collapse-block">
 <pre><code>
-# SSL setup (we assume the same certs for IMAP and SMTP here)
+# TLS setup (we assume the same certs for IMAP and SMTP here)
 smtpd_tls_cert_file = /etc/letsencrypt/live/your.domain/fullchain.pem
 smtpd_tls_key_file = /etc/letsencrypt/live/your.domain/privkey.pem
 smtpd_use_tls = yes
@@ -197,7 +197,7 @@ The download process is described in the [downloads page]({{ site.baseurl }}/dow
 
 ## Running Rspamd
 
-### Platforms with systemd (Arch, CentOS 7, Debian Jessie, Fedora, Ubuntu Xenial)
+### Platforms with systemd (Arch, CentOS 7, Debian, Fedora, Ubuntu)
 
 Packaging should start rspamd and configure it to run on startup on installation.
 
@@ -206,16 +206,6 @@ You can verify it's running as follows:
 ```
 systemctl status rspamd
 ```
-
-### Old Debian based systems (Ubuntu before xenial, Debian before Jessie)
-
-To enable run on startup:
-
-    update-rc.d rspamd defaults
-
-To start once:
-
-    /etc/init.d/rspamd start
 
 ### CentOS/RHEL 6
 
@@ -499,19 +489,15 @@ http {
                 proxy_set_header Host $http_host;
         }
         ssl on;
-        ssl_protocols TLSv1.2 TLSv1.1 TLSv1;
+        ssl_protocols TLSv1.2 TLSv1.3;
 
-        ssl_ciphers "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA256:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EDH+aRSA+AESGCM:EDH+aRSA+SHA256:EDH+aRSA:EECDH:!aNULL:!eNULL:!MEDIUM:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!RC4:!SEED";
+        ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;
         ssl_prefer_server_ciphers on;
-        ssl_session_cache builtin;
-        ssl_session_timeout 1m;
+        ssl_session_cache shared:TLS:10m;
+        ssl_session_timeout 1d;
         ssl_stapling on;
         ssl_stapling_verify on;
         server_tokens off;
-        # Do not forget to generate custom dhparam using
-        # openssl dhparam -out /etc/nginx/ssl/dhparam.pem 2048
-        ssl_dhparam /etc/nginx/dhparam.pem;
-        ssl_ecdh_curve prime256v1;
     }
 }
 {% endhighlight %}
@@ -600,7 +586,7 @@ Though Rspamd is free to use for any purpose many of the RBLs used in the defaul
 
 [DNSWL](https://www.dnswl.org/?page_id=9){:target="&#95;blank"} - Commercial use forbidden (see link for definition); Limit of 100k queries per day
 
-[Mailspike](http://mailspike.net/usage.html){:target="&#95;blank"} - Limit of 100k messages or queries per day
+[Mailspike](http://mailspike.org/usage.html){:target="&#95;blank"} - Limit of 100k messages or queries per day
 
 [Rspamd URIBL](http://www.rspamd.com/feed-policies.html){:target="&#95;blank"} - Commercial use forbidden (see link for definition); Limit of 250k queries per day
 

--- a/doc/workers/index.md
+++ b/doc/workers/index.md
@@ -67,10 +67,14 @@ bind_socket = "*v4:11333"; # any ipv4 address
 bind_socket = "*v6:11333"; # any ipv6 address
 ~~~
 
-It is possible to use systemd sockets (but not recommended- particularly if one uses official packages or requires use of multiple sockets):
+It is possible to use systemd sockets as configured via a [socket unit file](https://www.freedesktop.org/software/systemd/man/systemd.socket.html) (but not recommended- particularly if one uses official packages or requires use of multiple sockets):
 
 ~~~ucl
-bind_socket = "systemd:0"; # the first socket passed by systemd through environment (named sockets aren't supported)
+# Use the first socket passed through a systemd .socket file.
+bind_socket = "systemd:0";
+# Starting with Rspamd 2.4, one can use named socket files too. If the systemd
+# FileDescriptorName= option is not specified, the socket unit name can be used.
+bind_socket = "systemd:rspamd.socket";
 ~~~
 
 For UNIX sockets, it is also possible to specify owner and mode using this syntax:


### PR DESCRIPTION
* Fix typos, document new systemd named socket option

  The systemd option was added via "[Fix] Support listening on systemd
  sockets by name" in https://github.com/rspamd/rspamd/pull/3265

* Update module documentation

* quickstart: fix typos, updated outdated info

  * Fix typos and dead links.
  * Remove mentions of outdated platforms.
  * Simplify TLS config. Add TLS 1.3 support, use default ECDHE curves
  (which defaults to P256 on older versions), remove ECDH cipher which
  allows removal of ssl_dhparam, improve session cache.
