### PR TITLE
[doc] changes database to db in statistic.md

### DIFF
--- a/doc/configuration/statistic.md
+++ b/doc/configuration/statistic.md
@@ -92,7 +92,7 @@ Supported parameters for the redis backend are:
 - `servers`: IP or hostname with port for the redis server. Use an IP for the loopback interface, if you have defined localhost in /etc/hosts for both IPv4 and IPv6, or your redis server will not be found!
 - `write_servers` (optional): If needed, define dedicated servers for learning
 - `password` (optional): Password for the redis server
-- `database` (optional): Database to use (though it is recommended to use dedicated redis instances and not databases in redis)
+- `db` (optional): Database to use (though it is recommended to use dedicated redis instances and not databases in redis)
 - `min_tokens` : minimum number of words required for statistics processing
 - `min_learns` (optional): minimum learn count for **both** spam and ham classes to perform  classification
 - `autolearn` (optional): see below for details


### PR DESCRIPTION
`db` is used in all other modules documentation; using `database` might be confusing to some users.
Suggesting using the same keyword for consistency.
