### PR TITLE
Add generic reputation symbol to example config

### DIFF
--- a/doc/modules/reputation.md
+++ b/doc/modules/reputation.md
@@ -92,9 +92,16 @@ group "reputation" {
         "SPF_REPUTATION_SPAM" {
             weight = 2.0;
         }
+
+        "GENERIC_REPUTATION" {
+            weight = 1.0;
+        }
     }
 }
 ~~~
+
+The weight configured for these symbols are examples and you should tweak them
+to your situation.
 
 The picture below demonstrates how reputation tokens are being processed:
 


### PR DESCRIPTION
Without this configuration parameter the module fails to work

```
task; lua_task_insert_result_common: symbol insertion issue: unknown symbol GENERIC_REPUTATION; trace: [1]:{/usr/share/rspamd/plugins/reputation.lua:83 - add_symbol_score [Lua]}; [2]:{/usr/share/rspamd/plugins/reputation.lua:651 - continuation_cb [Lua]}; [3]:{/usr/share/rspamd/plugins/reputation.lua:961 - callback [Lua]}; [4]:{/usr/share/rspamd/lualib/lua_redis.lua:1296 - callback [Lua]}; [5]:{/usr/share/rspamd/lualib/lua_redis.lua:917 - <unknown> [Lua]};
```