### PR TITLE
Fix html list tgs inside jekyll table

### DIFF
--- a/doc/configuration/selectors.md
+++ b/doc/configuration/selectors.md
@@ -192,7 +192,7 @@ Data definition part defines what exactly needs to be extracted. Here is the lis
 | `emails` | 1.8+ | Get list of all emails. If no arguments specified, returns list of url objects. Otherwise, calls a specific method, e.g. `get_user`
 | `files` | 1.8+ | Get all attachments files
 | `from` | 1.8+ | Get MIME or SMTP from (e.g. `from('smtp')` or `from('mime')`, uses any type by default)
-| `header` | 1.8+ | Get header with the name that is expected as an argument. The optional second argument accepts list of flags:<ul><li>`full`: returns all headers with this name with all data (like task:get_header_full())</li><li>`strong`: use case sensitive match when matching header's name</li></ul>
+| `header` | 1.8+ | Get header with the name that is expected as an argument. The optional second argument accepts list of flags:{::nomarkdown}<ul><li><code>full</code>: returns all headers with this name with all data (like task:get_header_full())</li><li><code>strong</code>: use case sensitive match when matching header's name</li></ul>{:/}
 | `helo` | 1.8+ | Get helo value
 | `id` | 1.8+ | Return value from function's argument or an empty string, For example, `id('Something')` returns a string 'Something'
 | `ip` | 1.8+ | Get source IP address
@@ -205,7 +205,7 @@ Data definition part defines what exactly needs to be extracted. Here is the lis
 | `received` | 1.8+ | Get list of received headers. If no arguments specified, returns list of tables. Otherwise, selects a specific element, e.g. `by_hostname`
 | `request_header` | 1.8+ | Get specific HTTP request header. The first argument must be header name.
 | `symbol` | 2.6+ | Get symbol with the name that is expected as first argument. Returns the symbol table (like task:get_symbol())
-| `time` | 1.8+ | Get task timestamp. The first argument is type: <ul><li>`connect`: connection timestamp (default)</li><li>`message`: timestamp as defined by `Date` header</li></ul>The second argument is optional time format, see [os.date](http://pgl.yoyo.org/luai/i/os.date) description
+| `time` | 1.8+ | Get task timestamp. The first argument is type:{::nomarkdown}<ul><li><code>connect</code>: connection timestamp (default)</li><li><code>message</code>: timestamp as defined by <code>Date</code> header</li></ul>{:/}The second argument is optional time format, see [os.date](http://pgl.yoyo.org/luai/i/os.date) description
 | `to` | 1.8+ | Get principal recipient
 | `uid` | 2.6+ | Get ID of the task being processed
 | `urls` | 1.8+ | Get list of all urls. If no arguments specified, returns list of url objects. Otherwise, calls a specific method, e.g. `get_tld`


### PR DESCRIPTION
There are 2 problems [on that page](https://rspamd.com/doc/configuration/selectors.html) - jekyll from github pages doesn't generate HTML tags inside tables:

![image](https://user-images.githubusercontent.com/7151579/169655638-d91ac373-93b9-4641-947c-4155a940c0e3.png)

I found workaround [here](https://mademistakes.com/mastering-jekyll/kramdown-table-html/) and applied it. With this patch it looks better:

![image](https://user-images.githubusercontent.com/7151579/169655702-9302297a-0763-4ba5-bd9b-a60849eb7454.png)

But from github.com it shows jekyll-specific tags as is:

![image](https://user-images.githubusercontent.com/7151579/169655801-a63eb680-626e-4bb8-b88b-15e7faaa0786.png)

So I don't know, is it important to have nice look at official site or github.com?