### PR TITLE
kaspersky_se dos not support Unix sockets

### DIFF
--- a/doc/modules/antivirus.md
+++ b/doc/modules/antivirus.md
@@ -178,7 +178,7 @@ This engine uses HTTP [REST API version 1.0](https://help.kaspersky.com/ScanEngi
 # local.d/antivirus.conf
 kaspersky_se {
   symbol = "KAS_SE_VIRUS";
-  servers = "127.0.0.1:1234"; # Mandatory, supports Unix sockets as well
+  servers = "127.0.0.1:1234"; # Mandatory, dos not supports Unix sockets
   max_size = 2048000;
   timeout = 5.0; # Allow 5 seconds for scan
   scan_mime_parts = true; # Just attachments


### PR DESCRIPTION
I don't see support for unix sockets here

https://github.com/rspamd/rspamd/blob/2fa0e126c74e8702ef16759d92c1c05d28337195/lualib/lua_scanners/kaspersky_se.lua#L100

If I set unix socket in /etc/rspamd/local.d/antivirus.conf

kaspersky_se {
  symbol = "KAS_SE_VIRUS";
  servers = "/run/kavhttpd/kavhttpd.socket"; # Mandatory, supports Unix sockets as well
  max_size = 2048000;
  timeout = 5.0; # Allow 5 seconds for scan
  scan_mime_parts = true; # Just attachments
  use_files = false; # Or true if you want this mode
  use_https = false; # Enable if you like to use SSL
}

I get error in rspamd log

(normal) rspamd_http_message_from_url: cannot parse URL: http:///run/kavhttpd/kavhttpd.socket:0/scanmemory
(normal) lua_http_request: cannot create HTTP message from url http:///run/kavhttpd/kavhttpd.socket:0/scanmemory