### PR TITLE
Remove the disabling of scanning on port 587 (Exim doc)

### DIFF
--- a/doc/integration.md
+++ b/doc/integration.md
@@ -70,9 +70,6 @@ acl_check_spam:
   # +relay_from_hosts is assumed to be a list of hosts in configuration
   accept hosts = +relay_from_hosts
 
-  # do not scan messages from submission port (or maybe you want to?)
-  accept condition = ${if eq{$interface_port}{587}}
-
   # skip scanning for authenticated users (if desired?)
   accept authenticated = *
 


### PR DESCRIPTION
This line makes no sense for me, if you want to scan mails from your user, you can control this with the "authenticated" variable. But with this configuration anyone can skip the scanning if using port 587, which in my default config was not authenticated only. If anyone sees any benefit in the removed line, I'm open for feedback, on my systems it was just used to spam my mailboxes. Except for deny this spamming there should be no difference for the user.