### PR TITLE
More user-friendly link to rspamd at MacPorts

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -195,7 +195,7 @@ Users of NetBSD (and other systems with pkgsrc) can use [pkgsrc](https://pkgsrc.
 
 OpenBSD users can use [ports](https://openports.se/mail/rspamd).
 
-macOS users can install from [MacPorts](https://github.com/macports/macports-ports/blob/master/mail/rspamd/Portfile):
+macOS users can install from [MacPorts](https://ports.macports.org/port/rspamd):
 ```
 sudo port install rspamd
 sudo port load rspamd


### PR DESCRIPTION
This PR changes the link to MacPorts rspamd in downloads.md from a link to the Portfile's source code (which is only interesting to MacPorts developers) to a link to our ports web site (whicn is intended for users).