### PR TITLE
ratelimit: document allow_local setting

### DIFF
--- a/doc/modules/ratelimit.md
+++ b/doc/modules/ratelimit.md
@@ -40,6 +40,7 @@ the value of this option is 'postmaster, mailer-daemon'. Supported entries are:
 - `spam_factor_burst` - multiplier for burst when a spam message arrives (default: 0.98)
 - `max_rate_mult` - maximum and minimum (1/X) dynamic multiplier for rate (default: 5)
 - `max_bucket_mult` -  maximum and minimum (1/X) dynamic multiplier for rate (default: 10)
+- `allow_local` - a boolean that enables rate-limiting of local requests from rspamc or controller, including WebUI (default: false)
 - `rates` - a table of allowed rates in several forms
 
 


### PR DESCRIPTION
@fatalbanana @vstakhov Should we add a debug message here?
https://github.com/rspamd/rspamd/blob/40a0a9674d7058b6b0392badeaaa74020456a1d5/src/plugins/lua/ratelimit.lua
It's a bit confusing when module debugging is on but nothing happens at all.