### PR TITLE
Fix links to workers in MTA Integration

### DIFF
--- a/doc/tutorials/integration.md
+++ b/doc/tutorials/integration.md
@@ -28,7 +28,7 @@ In addition, [this section of the document]({{ site.baseurl }}/doc/tutorials/int
 
 ## Using Rspamd with Postfix MTA
 
-Starting with version 1.6, for integrating Rspamd with Postfix, it is recommended to utilize the Rspamd proxy worker in Milter mode, as described in [rspamd proxy worker](./workers/rspamd_proxy.html). 
+Starting with version 1.6, for integrating Rspamd with Postfix, it is recommended to utilize the Rspamd proxy worker in Milter mode, as described in [rspamd proxy worker](../workers/rspamd_proxy.html). 
 
 ### Configuring Postfix
 
@@ -186,7 +186,7 @@ For further information, please refer to the James' extensions for Rspamd docume
 
 ## Integration with Stalwart Mail Server
 
-Rspamd can easily be integrated with Stalwart Mail Server using the `milter` protocol. In order to enable Milter support in rspamd, follow the instructions in the [proxy worker](./workers/rspamd_proxy.html) chapter. 
+Rspamd can easily be integrated with Stalwart Mail Server using the `milter` protocol. In order to enable Milter support in rspamd, follow the instructions in the [proxy worker](../workers/rspamd_proxy.html) chapter. 
 
 After setting up the proxy worker to handle milter requests, configure Stalwart Mail Server to use rspamd via milter by adding the following entries to the `etc/config.toml` configuration file:
 


### PR DESCRIPTION
Links to rspamd worker page go to incorrect address - https://rspamd.com/doc/tutorials/integration.html