### PR TITLE
Updated docs according to the issue #759

### DIFF
--- a/_drafts/template_release.md
+++ b/_drafts/template_release.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: "Rspamd 3.8... has been released"
+categories: announce
+---
+
+This release includes new features for `replies` and `known_senders` modules. `replies` module now can check `in-reply-to` mails to verify senders and their recipients. `known_senders` module can check incoming mails if sender and recipients have already been verified. 

--- a/_posts/2024-02-26-rspamd-3.8.template.md
+++ b/_posts/2024-02-26-rspamd-3.8.template.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: "Rspamd 3.8... has been released"
+categories: announce
+---
+
+This release includes new features for `replies` and `known_senders` modules. `replies` module now can check `in-reply-to` mails to verify senders and their recipients. `known_senders` module can check incoming mails if sender and recipients have already been verified. 

--- a/doc/modules/known_senders.md
+++ b/doc/modules/known_senders.md
@@ -15,12 +15,14 @@ The `known_senders` plugin is designed to help you track and categorize email se
    - [Maximum Time to Live](#maximum-time-to-live)
    - [Use Bloom Filters](#use-bloom-filters)
    - [Unknown Sender Symbol](#unknown-sender-symbol)
-
+   - [Verified Incoming Mail Global Symbol](#verified-incoming-mail-global-symbol)
+   - [Verified Incoming Mail Local Symbol](#verified-incoming-mail-local-symbol)
+   - [Sender Prefix](#sender-prefix)
 ---
 
 ## Plugin Overview
 
-The `known_senders` plugin is used to maintain a list of known sender domains and classify incoming emails based on these domains. It can be especially useful for distinguishing known senders from potentially malicious or unknown ones. This plugin is available from the version 3.7.0.
+The `known_senders` plugin is used to maintain a list of known sender domains and classify incoming emails based on these domains. It can be especially useful for distinguishing known senders from potentially malicious or unknown ones. Also it can check if incoming `in-reply-to` mail sender and recipients are verified. This plugin is available from the version 3.7.0.
 
 ## Configuration
 
@@ -43,6 +45,15 @@ use_bloom = false;
 
 # Insert symbol for new senders from the specific domains
 symbol_unknown = 'UNKNOWN_SENDER';
+
+# Insert symbol for verified sender in global replies set
+symbol_check_mail_global = 'INC_MAIL_KNOWN_GLOBALLY';
+
+# Insert symbol for verified recipients in local replies set
+symbol_check_mail_local = 'INC_MAIL_KNOWN_LOCALLY';
+
+# Prefix for replies sets
+sender_prefix = 'rsrk';
 ```
 
 ### Domains
@@ -71,3 +82,16 @@ symbol_unknown = 'UNKNOWN_SENDER';
 ### Unknown Sender Symbol
 
 - **Description**: The `symbol_unknown` parameter specifies the symbol that will be inserted for new senders from the domains listed in the `domains` configuration. This symbol can be used to further classify emails from unknown senders.
+
+### Verified Incoming Mail Global Symbol
+
+- **Description**: The `symbol_check_mail_global` parameter specifies the symbol that will be inserted if sender in the incoming mail is verified by `replies` module. Icoming mail is a `in-reply-to` mail.
+ 
+### Verified Incoming Mail Local Symbol
+
+- **Description**: The `symbol_check_mail_global` parameter specifies the symbol that will be inserted if recipients in the incoming `in-reply-to` mail is verified by replies module.
+
+### Sender Prefix
+
+- **Description**: The `sender_prefix` parameter is used to define keys in the redis that denote replies sets.
+- **Note**: If you changed `sender_prefix` in `local.d/replies.conf` you also need to change it in the `local.d/known_senders.conf`.  

--- a/doc/modules/known_senders.md
+++ b/doc/modules/known_senders.md
@@ -85,11 +85,11 @@ sender_prefix = 'rsrk';
 
 ### Verified Incoming Mail Global Symbol
 
-- **Description**: The `symbol_check_mail_global` parameter specifies the symbol that will be inserted if sender in the incoming mail is verified by `replies` module. Icoming mail is a `in-reply-to` mail.
+- **Description**: The `symbol_check_mail_global` parameter specifies the symbol that will be inserted if sender in the incoming mail is verified by `replies` module.
  
 ### Verified Incoming Mail Local Symbol
 
-- **Description**: The `symbol_check_mail_global` parameter specifies the symbol that will be inserted if recipients in the incoming `in-reply-to` mail is verified by replies module.
+- **Description**: The `symbol_check_mail_global` parameter specifies the symbol that will be inserted if recipients in the incoming mail is verified by `replies` module.
 
 ### Sender Prefix
 

--- a/doc/modules/known_senders.md
+++ b/doc/modules/known_senders.md
@@ -89,7 +89,7 @@ sender_prefix = 'rsrk';
  
 ### Verified Incoming Mail Local Symbol
 
-- **Description**: The `symbol_check_mail_global` parameter specifies the symbol that will be inserted if recipients in the incoming mail is verified by `replies` module.
+- **Description**: The `symbol_check_mail_local` parameter specifies the symbol that will be inserted if recipients in the incoming mail is verified by `replies` module.
 
 ### Sender Prefix
 

--- a/doc/modules/replies.md
+++ b/doc/modules/replies.md
@@ -5,7 +5,7 @@ title: Replies module
 
 # Replies module
 
-This module gathers the `message-id` header of emails that authenticated users have sent and saves the corresponding hashes to Redis. These hashes expire after a predetermined length of time, which can be set to a maximum of 24 hours by default. Additionally, the module creates hashes of the `in-reply-to` headers of all received messages and checks them for matches, i.e., messages that were sent in response to messages that our system initiated. The module then generates a symbol that can be used to adjust the scoring or force an action, such as accepting the message with no action taken, depending on the configuration.
+This module gathers the `message-id` header of emails that authenticated users have sent and saves the corresponding hashes to Redis. These hashes expire after a predetermined length of time, which can be set to a maximum of 24 hours by default. Additionally, the module creates hashes of the `in-reply-to` headers of all received messages and checks them for matches, i.e., messages that were sent in response to messages that our system initiated. After that it approves all recipients of the current sender and adds them to the `local replies set` of this sender (default maximum size is 20). `local replies set` is used to check approved recipients for current sender. This `local replies set` has the time to expire (default is 1 day) after which it is removed from the redis. After this all recipients are also added to the `global replies set` (default maximum size is 30). `global replies set` is used to determine whether the sender is approved. The module then generates a symbol that can be used to adjust the scoring or force an action, such as accepting the message with no action taken, depending on the configuration.
 
 
 ## Configuration
@@ -15,7 +15,11 @@ Settings for the module are described below (default values are indicated in bra
 - `action`: apply the given action to messages identified as replies (should typically be set to "no action" to accept)
 - `expire`: time, in seconds, after which to expire records (default is one day).
 - `key_prefix`: string prefixed to keys in Redis (default `rr`)
+- `sender_prefix`: string prefixed to replies sets (default `rsrk`)
+- `sender_key_global`: string that is used as a key to the global replies set
 - `symbol`: symbol yielded on messages identified as replies.
+- `max_local_size`: maximum ammount of senders that are in the local replies set (default is 20)
+- `max_global_size`: maximum ammount of senders that are in the global replies set (default is 30)
 
 Additionally, you will need to set up Redis servers to store data, such as `servers` or `read_servers` and `write_servers`. You can specify all standard Redis arguments, including password, timeout, database, and so on.
 
@@ -29,8 +33,11 @@ Configuration should be added to `/etc/rspamd/local.d/replies.conf`:
 # These are default settings you may want to change
 expire = 1d;
 key_prefix = "rr";
+sender_prefix = "rsrk";
 message = "Message is reply to one we originated";
 symbol = "REPLY";
+max_local_size = 20;
+max_global_size = 30;
 # Module specific redis configuration
 #servers = "localhost";
 ~~~


### PR DESCRIPTION
According to the [rspamd/rspamd.com#759](https://github.com/rspamd/rspamd.com/issues/759) documentation for `replies` and `known_senders` modules were updated. A template for release notes was also provided.