### PR TITLE
Fix abusix documentation link

### DIFF
--- a/doc/modules/rbl.md
+++ b/doc/modules/rbl.md
@@ -11,7 +11,7 @@ The RBL module offers support for checking various message elements, such as the
 
 By default, Rspamd comes with a set of RBL rules pre-configured for popular resources that are often free for non-profit usage, subject to fair usage policies. If you require a different level of support or access, please contact the relevant vendors.
 
-For example, you can use [Abusix Mail Intelligence](https://docs.abusix.com/abusix-mail-intelligence/getting-started/dmw9dcwSGSNQiLTssFAnBW#rspamd) or [Spamhaus DQS](https://github.com/spamhaus/rspamd-dqs) or any other RBL provider that suits your needs.
+For example, you can use [Abusix Mail Intelligence](https://abusix.com/docs/rspamd/) or [Spamhaus DQS](https://github.com/spamhaus/rspamd-dqs) or any other RBL provider that suits your needs.
 
 {% include toc.html %}
 


### PR DESCRIPTION
Looks like abusix has had a site reorganisation as the original URL now 404s.

As an aside, it might be worthwhile investigating a github action for checking URLs inside markdown files.

With a quick search, https://github.com/UmbrellaDocs/linkspector looks like it might qualify.