### PR TITLE
Add information about Classifier header in Controller HTTP Endpoint

### DIFF
--- a/doc/configuration/statistic.md
+++ b/doc/configuration/statistic.md
@@ -33,7 +33,7 @@ The default configuration settings can be found in the `$CONFDIR/statistic.conf`
 
 ~~~hcl
 classifier "bayes" {
-  # name = "bayes";  # 'name' parameter must be set if multiple classifiers are defined
+  # name = "custom";  # 'name' parameter must be set if multiple classifiers are defined
   tokenizer {
     name = "osb";
   }

--- a/doc/configuration/statistic.md
+++ b/doc/configuration/statistic.md
@@ -33,8 +33,7 @@ The default configuration settings can be found in the `$CONFDIR/statistic.conf`
 
 ~~~hcl
 classifier "bayes" {
-  # name must be set if multiply classifiers presented
-  # name = "bayes";
+  # name = "bayes";  # 'name' parameter must be set if multiple classifiers are defined
   tokenizer {
     name = "osb";
   }

--- a/doc/configuration/statistic.md
+++ b/doc/configuration/statistic.md
@@ -33,6 +33,8 @@ The default configuration settings can be found in the `$CONFDIR/statistic.conf`
 
 ~~~hcl
 classifier "bayes" {
+  # name must be set if multiply classifiers presented
+  # name = "bayes";
   tokenizer {
     name = "osb";
   }

--- a/doc/developers/protocol.md
+++ b/doc/developers/protocol.md
@@ -274,13 +274,13 @@ The following endpoints are valid merely on the controller. All of these may req
 These accept `POST`. Headers which must be set are:
 
 - `Flag`: flag identifying fuzzy storage
-- `Weight`:  weight to add to hashes
+- `Weight`: weight to add to hashes
 
 * `/learnspam` - Trains bayes classifier on spam message
 * `/learnham` - Trains bayes classifier on ham message
 * `/checkv2` - Checks message and return action (same as normal worker)
 
-These also accept `POST`. . Headers which may be set are:
+These also accept `POST`. Headers which may be set are:
 
 - `Classifier`: classifier name to be learned, if unset - all available classifiers will be learned
 

--- a/doc/developers/protocol.md
+++ b/doc/developers/protocol.md
@@ -271,16 +271,20 @@ The following endpoints are valid merely on the controller. All of these may req
 * `/fuzzyadd` - Adds message to fuzzy storage
 * `/fuzzydel` - Removes message from fuzzy storage
 
-These accept `POST`. Headers which may be set are:
+These accept `POST`. Headers which must be set are:
 
 - `Flag`: flag identifying fuzzy storage
-- `Weight`: weight to add to hashes
+- `Weight`:  weight to add to hashes
 
 * `/learnspam` - Trains bayes classifier on spam message
 * `/learnham` - Trains bayes classifier on ham message
 * `/checkv2` - Checks message and return action (same as normal worker)
 
-These also accept `POST`. The below endpoints all use `GET`:
+These also accept `POST`. . Headers which may be set are:
+
+- `Classifier`: classifier name to be learned, if unset - all available classifiers will be learned
+
+The below endpoints all use `GET`:
 
 * `/errors` - Returns error messages from ring buffer
 * `/stat` - Returns statistics

--- a/doc/developers/protocol.md
+++ b/doc/developers/protocol.md
@@ -282,9 +282,9 @@ These accept `POST`. Headers which must be set are:
 
 These also accept `POST`. Headers which may be set are:
 
-- `Classifier`: classifier name to be learned, if unset - all available classifiers will be learned
+- `Classifier`: classifier name to be learned. If not specified, all available classifiers will be learned.
 
-The below endpoints all use `GET`:
+The following endpoints all use `GET`:
 
 * `/errors` - Returns error messages from ring buffer
 * `/stat` - Returns statistics


### PR DESCRIPTION
Add information about `classifier` header in `/learnspam` and `/learnham` controller http endpoint.