### PR TITLE
Added Ubuntu Noble 24.04 to supported versions

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -92,6 +92,7 @@ Rspamd supports the following .deb based distributives:
 - **Debian bullseye**
 - **Ubuntu focal** (since 2.5)
 - **Ubuntu jammy** (since 3.3)
+- **Ubuntu noble** (since 3.9)
 
 To install the rspamd <a class="text-decoration-none text-reset" href="#stableSys2">stable<sup>1</sup></a> apt repository, please use the following commands:
 


### PR DESCRIPTION
According to [this issue](https://github.com/rspamd/rspamd/issues/5040#issuecomment-2225504049) rspamd supports Ubuntu Noble 24.04 since version 3.9.0. I have added this version to the list of supported OS in the downloads page.