### PR TITLE
Document log_json logging configuration parameter

### DIFF
--- a/doc/configuration/logging.md
+++ b/doc/configuration/logging.md
@@ -55,6 +55,7 @@ Here is a summary of the logging parameters, each of which can be redefined or d
 | `debug_modules` | A list of modules that are enabled for debugging.
 | `log_usec` | Log microseconds (e.g. `11:43:16.68071`). Default: `false`.
 | `log_severity` (2.8+) | Log severity explicitly (e.g. `[info]` or `[error]`). Default: `false`.
+| `log_json` (3.8+) | If `true` logs are emitted in JSON format (implies `log_severity=true` and `systemd=false`). Default: `false`.
 
 
 ### Defined debug modules


### PR DESCRIPTION
Rspamd has supported emitting logs in JSON format since https://github.com/rspamd/rspamd/pull/4674 which is included in 3.8.0, however this configuration parameter isn't documented outside the [release notes](https://rspamd.com/announce/2024/01/19/rspamd-3.8.0.html). To make this parameter more discoverable, this PR fixes the documentation for the logging settings accordingly.